### PR TITLE
mirrors.yml: various updates

### DIFF
--- a/mirrors.yml
+++ b/mirrors.yml
@@ -1,12 +1,18 @@
 origin:
     desc: AOSC main repository (hosted by Aperture Science Limited)
-    url: https://repo.aosc.io/
+    url: https://repo.aosc.io/anthon/
 origin4:
     desc: AOSC main repository (hosted by Aperture Science Limited, IPv4 only)
-    url: https://v4.repo.aosc.io/
+    url: https://v4.repo.aosc.io/anthon/
 origin6:
     desc: AOSC main repository (hosted by Aperture Science Limited, IPv6 only)
-    url: https://v6.repo.aosc.io/
+    url: https://v6.repo.aosc.io/anthon/
+repo-us:
+    desc: AOSC main repository (United States)
+    url: https://repo-us.aosc.io/anthon/
+cernet:
+    desc: CERNET mirror auto-redirection service with GeoIP optimization
+    url: https://mirrors.cernet.edu.cn/anthon/
 geekpie:
     desc: GeekPie (ShanghaiTech University) Open Source Mirror
     url: https://mirrors.shanghaitech.edu.cn/anthon/
@@ -18,10 +24,7 @@ nluug:
     url: https://ftp.nluug.nl/os/Linux/distr/anthon/
 tsukuba:
     desc: Tsukuba WIDE Public Mirror service
-    url: http://ftp.tsukuba.wide.ad.jp/Linux/anthon/
-tencent:
-    desc: Tencent Open Source Software Mirror
-    url: https://mirrors.cloud.tencent.com/anthon/
+    url: https://ftp.tsukuba.wide.ad.jp/Linux/anthon/
 tuna:
     desc: Tsinghua Open Source Mirror (TUNA)
     url: https://mirrors.tuna.tsinghua.edu.cn/anthon/
@@ -32,8 +35,14 @@ tuna6:
     desc: Tsinghua Open Source Mirror (TUNA, IPv6 only)
     url: https://mirrors6.tuna.tsinghua.edu.cn/anthon/
 bfsu:
-    desc: Beijing Foreign Studies University Open Source Mirror
+    desc: Beijing Foreign Studies University Open Source Mirror (BFSU)
     url: https://mirrors.bfsu.edu.cn/anthon/
+bfsu4:
+    desc: Beijing Foreign Studies University Open Source Mirror (BFSU, IPv4 only)
+    url: https://mirrors4.bfsu.edu.cn/anthon/
+bfsu6:
+    desc: Beijing Foreign Studies University Open Source Mirror (BFSU, IPv6 only)
+    url: https://mirrors6.bfsu.edu.cn/anthon/
 ustc:
     desc: University of Science and Technology of China OSS Mirror
     url: https://mirrors.ustc.edu.cn/anthon/
@@ -51,15 +60,12 @@ hexhu:
     url: https://mirror.hu.fo/anthon/
 fastly:
     desc: Fastly CDN
-    url: https://aosc-repo.freetls.fastly.net/
+    url: https://aosc-repo.freetls.fastly.net/anthon/
 nju:
     desc: NJU Mirror (Nanjing University)
     url: https://mirror.nju.edu.cn/anthon/
-koddoshk:
-    desc: KoDDoS Hong Kong
-    url: https://mirror-hk.koddos.net/anthon/
 xtom:
-    desc: xTom Open Source Software Mirror
+    desc: xTom Open Source Software Mirror (United States)
     url: https://mirror.xtom.com/anthon/
 xtom-estonia:
     desc: xTom Open Source Software Mirror (Estonia)
@@ -74,14 +80,14 @@ xtom-netherlands:
     desc: xTom Open Source Software Mirror (Netherlands)
     url: https://mirror.xtom.nl/anthon/
 aliyun:
-    desc: Alibaba Cloud Open Source Mirror"
+    desc: Alibaba Cloud Open Source Mirror
     url: https://mirrors.aliyun.com/anthon/
 iscas:
     desc: ISCAS Open Source Mirror
     url: https://mirror.iscas.ac.cn/anthon/
 jlu:
     desc: Jilin University Open Source Mirror
-    url: http://mirrors.jlu.edu.cn/anthon/
+    url: https://mirrors.jlu.edu.cn/anthon/
 sjtug:
     desc: SJTUG Mirror (Shanghai Jiao Tong University)
     url: https://mirror.sjtu.edu.cn/anthon/
@@ -91,3 +97,9 @@ nit:
 sdu:
     desc: SDU Mirrors (Shandong University)
     url: https://mirrors.sdu.edu.cn/anthon/
+qlut:
+    desc: QLUT OSS Mirrors (Qilu University of Technology)
+    url: https://mirrors.qlu.edu.cn/anthon/
+pku:
+    desc: PKU OSS Mirrors (Peking University)
+    url: https://mirrors.pku.edu.cn/anthon/


### PR DESCRIPTION
  - remove `tencent` mirror, sync discontinued by downstream
  - remove `koddos-hk`, sync discontinued by downstream
  - add `bfsu4` and `bfsu6`, BFSU's v4/v6 only domain
  - add `pku`, Peking University's Mirror
  - add `qlut`, Qilu University of Technology's Mirror
  - add `cernet`, CERNET mirrors' redirection service with IP-based optimization
  - use https for `tsukuba` and `jlu` mirror
  - declare `xtom` mirror's location in US
  - add /anthon/ suffix for `origin`, `origin4`, `origin6` and `fastly`
  - fix some typo